### PR TITLE
Sonar ainda requer .net core 2.1

### DIFF
--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -1,5 +1,20 @@
 FROM microsoft/dotnet:3.0-sdk as build-environment
 
+RUN apt-get install wget
+RUN apt-get install gpg
+
+RUN wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg && \
+mv microsoft.asc.gpg /etc/apt/trusted.gpg.d/ && \
+wget -q https://packages.microsoft.com/config/debian/9/prod.list && \
+mv prod.list /etc/apt/sources.list.d/microsoft-prod.list && \
+chown root:root /etc/apt/trusted.gpg.d/microsoft.asc.gpg && \
+chown root:root /etc/apt/sources.list.d/microsoft-prod.list
+
+RUN apt-get update && \
+apt-get install apt-transport-https && \
+apt-get update && \
+apt-get install aspnetcore-runtime-2.1=2.1.0-1 && \
+
 RUN apt-get update && \
    apt-get install -y openjdk-8-jre && \
    apt-get clean;


### PR DESCRIPTION
Sonar ainda requer .net core 2.1 para executar.